### PR TITLE
Add note to sakuracloud_simple_monitor.notify_interval

### DIFF
--- a/src/terraform/docs/guides/upgrade_to_v2.0.0.md
+++ b/src/terraform/docs/guides/upgrade_to_v2.0.0.md
@@ -347,6 +347,7 @@ v2では代わりに各リソースで[timeoutsブロック](https://www.terrafo
 - `health_check`
     - `delay_loop`(移動) => トップレベルへ移動
     - `status`(データ型変更) => 文字列から数値型へ変更
+- `notify_interval`(単位変更) => 秒単位で指定から時間単位で指定するように変更    
 
 ---
 
@@ -671,6 +672,7 @@ resource "sakuracloud_server" "example" {
 - `health_check`
     - `delay_loop`(移動) => トップレベルへ移動
     - `status`(データ型変更) => 文字列から数値型へ変更
+- `notify_interval`(単位変更) => 秒単位で指定から時間単位で指定するように変更    
 
 ---
 


### PR DESCRIPTION
terraform-provider-sakuracloudでシンプルモニタの再通知間隔`notify_interval`はv1/v2の間で単位が変更となった。

v1: 秒(seconds)単位
v2: 時間(hours)単位

この変更をアップグレードガイドに追記する。