### PR TITLE
mkdocs周りのアップグレード

### DIFF
--- a/.github/actions/mkdocs/Dockerfile
+++ b/.github/actions/mkdocs/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 MAINTAINER Usacloud Members<sacloud.users@gmail.com>
 
 RUN  apt-get update && apt-get -y install \

--- a/.github/actions/mkdocs/requirements.txt
+++ b/.github/actions/mkdocs/requirements.txt
@@ -1,3 +1,3 @@
-mkdocs>=1.1
+mkdocs>=1.3
 markdown>=3.3
-mkdocs-material>=7.1
+mkdocs-material>=8.2


### PR DESCRIPTION
closes #140 

- ベースイメージをUbuntu22.04へ
- mkdocs >= 1.3
- mkdocs-material >= 8.2