### PR TITLE
mkdocs build --strictによるリンク切れの検出

### DIFF
--- a/.github/actions/mkdocs/entrypoint.sh
+++ b/.github/actions/mkdocs/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/sh -l
 
 cd $1
-mkdocs build
+mkdocs build --strict

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -24,3 +24,47 @@ jobs:
         uses: sacloud/textlint-action@v0.0.1
         with:
           working-directory: ${{ matrix.working-directory }}
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Unshallow
+        run: git fetch --prune --unshallow
+
+      - name: Build a document with mkdocs - src/terraform
+        uses: ./.github/actions/mkdocs
+        with:
+          working-directory: './src/terraform'
+
+      - name: Build a document with mkdocs - src/terraform-v1
+        uses: ./.github/actions/mkdocs
+        with:
+          working-directory: './src/terraform-v1'
+
+      - name: Build a document with mkdocs - src/top
+        uses: ./.github/actions/mkdocs
+        with:
+          working-directory: './src/top'
+
+      - name: Build a document with mkdocs - src/usacloud
+        uses: ./.github/actions/mkdocs
+        with:
+          working-directory: './src/usacloud'
+
+      - name: Build a document with mkdocs - src/usacon
+        uses: ./.github/actions/mkdocs
+        with:
+          working-directory: './src/usacon'
+
+      - name: Build a document with mkdocs - src/autoscaler
+        uses: ./.github/actions/mkdocs
+        with:
+          working-directory: './src/autoscaler'
+
+      - name: Build a document with mkdocs - src/prometheus
+        uses: ./.github/actions/mkdocs
+        with:
+          working-directory: './src/prometheus'

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,20 @@ build-mkdocs:
 	@echo "building sacloud/mkdocs:local"
 	@docker build -t sacloud/mkdocs:local .github/actions/mkdocs
 
+build-all:
+	@echo "running mkdocs in $(TOP_DIR)..."
+	@(cd $(TOP_DIR); make build)
+	@echo "running mkdocs in $(TERRAFORM_V2_DIR)..."
+	@(cd $(TERRAFORM_V2_DIR); make build)
+	@echo "running mkdocs in $(USACLOUD_DIR)..."
+	@(cd $(USACLOUD_DIR); make build)
+	@echo "running mkdocs in $(USACON_DIR)..."
+	@(cd $(USACON_DIR); make build)
+	@echo "running mkdocs in $(AUTOSCALER_DIR)..."
+	@(cd $(AUTOSCALER_DIR); make build)
+	@echo "running mkdocs in $(PROMETHEUS_DIR)..."
+	@(cd $(PROMETHEUS_DIR); make build)
+
 lint:
 	@echo "running textlint in $(TOP_DIR)..."
 	@(cd $(TOP_DIR); make lint)
@@ -27,6 +41,7 @@ lint:
 	@(cd $(AUTOSCALER_DIR); make lint)
 	@echo "running textlint in $(PROMETHEUS_DIR)..."
 	@(cd $(PROMETHEUS_DIR); make lint)
+
 
 .PHONY: preview-top
 preview-top:

--- a/src/autoscaler/Makefile
+++ b/src/autoscaler/Makefile
@@ -4,8 +4,9 @@ default: lint
 build:
 	@docker run -it --rm \
            -v $$PWD:/workdir \
-           -p 8080:8080 \
-           sacloud/mkdocs:latest build --clean --quiet
+           -w /workdir \
+           --entrypoint mkdocs \
+           sacloud/mkdocs:local build --clean --strict
 
 preview:
 	@echo "servind docs on http://localhost:8080"

--- a/src/prometheus/Makefile
+++ b/src/prometheus/Makefile
@@ -4,8 +4,9 @@ default: lint
 build:
 	@docker run -it --rm \
            -v $$PWD:/workdir \
-           -p 8080:8080 \
-           sacloud/mkdocs:latest build --clean --quiet
+           -w /workdir \
+           --entrypoint mkdocs \
+           sacloud/mkdocs:local build --clean --strict
 
 preview:
 	@echo "servind docs on http://localhost:8080"

--- a/src/terraform-v1/Makefile
+++ b/src/terraform-v1/Makefile
@@ -4,8 +4,9 @@ default: lint
 build:
 	@docker run -it --rm \
            -v $$PWD:/workdir \
-           -p 80:80 \
-           sacloud/mkdocs:latest build --clean --quiet
+           -w /workdir \
+           --entrypoint mkdocs \
+           sacloud/mkdocs:local build --clean --strict
 
 preview:
 	@echo "servind docs on http://localhost:8080"

--- a/src/terraform/Makefile
+++ b/src/terraform/Makefile
@@ -4,8 +4,9 @@ default: lint
 build:
 	@docker run -it --rm \
            -v $$PWD:/workdir \
-           -p 80:80 \
-           sacloud/mkdocs:latest build --clean --quiet
+           -w /workdir \
+           --entrypoint mkdocs \
+           sacloud/mkdocs:local build --clean --strict
 
 preview:
 	@echo "servind docs on http://localhost:8080"

--- a/src/top/Makefile
+++ b/src/top/Makefile
@@ -4,8 +4,9 @@ default: lint
 build:
 	@docker run -it --rm \
            -v $$PWD:/workdir \
-           -p 80:80 \
-           sacloud/mkdocs:latest build --clean --quiet
+           -w /workdir \
+           --entrypoint mkdocs \
+           sacloud/mkdocs:local build --clean --strict
 
 preview:
 	@echo "servind docs on http://localhost:8080"

--- a/src/usacloud/Makefile
+++ b/src/usacloud/Makefile
@@ -4,8 +4,9 @@ default: lint
 build:
 	@docker run -it --rm \
            -v $$PWD:/workdir \
-           -p 80:80 \
-           sacloud/mkdocs:latest build --clean --quiet
+           -w /workdir \
+           --entrypoint mkdocs \
+           sacloud/mkdocs:local build --clean --strict
 
 preview:
 	@echo "servind docs on http://localhost:8080"

--- a/src/usacon/Makefile
+++ b/src/usacon/Makefile
@@ -4,8 +4,9 @@ default: lint
 build:
 	@docker run -it --rm \
            -v $$PWD:/workdir \
-           -p 80:80 \
-           sacloud/mkdocs:latest build --clean --quiet
+           -w /workdir \
+           --entrypoint mkdocs \
+           sacloud/mkdocs:local build --clean --strict
 
 preview:
 	@echo "servind docs on http://localhost:8080"


### PR DESCRIPTION
closes #39 

開発環境やCIでリンク切れを検出可能にする