### PR TITLE
terraform-provider-sakuracloud v2.23->v2.25

### DIFF
--- a/src/terraform/docs/d/enhanced_db.md
+++ b/src/terraform/docs/d/enhanced_db.md
@@ -54,6 +54,7 @@ A `condition` block supports the following:
 ## Attribute Reference
 
 * `id` - The id of the sakuracloud_enhanced_db.
+* `allowed_networks` - A list of CIDR blocks allowed to connect.
 * `database_name` - The name of database.
 * `database_type` - The type of database.
 * `description` - The description of the EnhancedDB.

--- a/src/terraform/docs/d/server.md
+++ b/src/terraform/docs/d/server.md
@@ -46,6 +46,7 @@ data "sakuracloud_server" "foobar" {
     - `standard`: 通常  
     - `dedicatedcpu`: コア専有  
 * `core` - vCPU数
+* `cpu_model` - CPUモデル
 * `description` - 説明
 * `disks` - サーバに接続されているディスクのIDのリスト
 * `dns_servers` - サーバが属するゾーンのDNSサーバのIPアドレスのリスト

--- a/src/terraform/docs/guides/upgrade_to_v2.23.0.md
+++ b/src/terraform/docs/guides/upgrade_to_v2.23.0.md
@@ -1,0 +1,9 @@
+# アップグレードガイド(v2.23)
+
+## 目次
+
+- [sakuracloud_proxylb: http_backend_keep_aliveのスキーマ変更](#diff1)
+  
+### sakuracloud_proxylb: http_backend_keep_aliveのスキーマ変更 {: #diff1 }
+
+エンハンスドロードバランサの実サーバとのHTTP持続接続のデフォルト値が空から`SAFE`に変更されました。

--- a/src/terraform/docs/guides/upgrade_to_v2.24.0.md
+++ b/src/terraform/docs/guides/upgrade_to_v2.24.0.md
@@ -1,0 +1,22 @@
+# アップグレードガイド(v2.24)
+
+## 目次
+
+- [sakuracloud_enhanced_db: タイプ/リージョン/接続元ネットワーク指定](#diff1)
+  
+### sakuracloud_enhanced_db: タイプ/リージョン/接続元ネットワーク指定 {: #diff1 }
+
+指定可能な項目が追加されました。
+
+```hcl
+resource "sakuracloud_enhanced_db" "foobar" {
+  name           = "example"
+  database_name  = "example"
+  password       = "password"
+  
+  # 以下3つが追加
+  database_type  = "tidb" # or mariadb
+  region         = "is1"
+  allowed_networks = ["192.0.2.1/32"]
+}
+```

--- a/src/terraform/docs/guides/upgrade_to_v2.25.0.md
+++ b/src/terraform/docs/guides/upgrade_to_v2.25.0.md
@@ -1,0 +1,45 @@
+# アップグレードガイド(v2.25)
+
+## 目次
+
+- [sakuracloud_proxylb: リクエストヘッダによる振り分けルール](#diff1)
+- [sakuracloud_server: AMDプラン](#diff2)
+  
+### sakuracloud_proxylb: リクエストヘッダによる振り分けルール {: #diff1 }
+
+ルールの指定時にリクエストヘッダ関連のパラメータを指定可能になりました。
+
+```hcl
+resource "sakuracloud_proxylb" "foobar" {
+  # ...中略...
+  
+  rule {
+    action             = "fixed"
+    group              = "group1"
+    
+    request_header_name  = "foo"
+    request_header_value = "1"
+    
+    request_header_value_ignore_case = "true"
+    request_header_value_not_match   = "true"
+    
+    # ...
+  }
+}
+```
+
+### sakuracloud_server: AMDプラン {: #diff2 }
+
+AMDプランに対応しました。
+
+```hcl
+resource "sakuracloud_server" "foobar" {
+  name       = "example"
+  core       = 32
+  memory     = 120
+  cpu_model  = "amd_epyc_7713p"
+  commitment = "dedicatedcpu"
+
+  # ...
+}
+```

--- a/src/terraform/docs/index.md
+++ b/src/terraform/docs/index.md
@@ -30,7 +30,7 @@ terraform {
 
       # We recommend pinning to the specific version of the SakuraCloud Provider you're using
       # since new versions are released frequently
-      version = "2.17.0"
+      version = "2.25.0"
       #version = "~> 2"
     }
   }

--- a/src/terraform/docs/provider.md
+++ b/src/terraform/docs/provider.md
@@ -13,7 +13,7 @@ terraform {
 
       # We recommend pinning to the specific version of the SakuraCloud Provider you're using
       # since new versions are released frequently
-      version = "2.17.0"
+      version = "2.25.0"
       #version = "~> 2"
     }
   }

--- a/src/terraform/docs/r/certificate_authority.md
+++ b/src/terraform/docs/r/certificate_authority.md
@@ -11,7 +11,7 @@ terraform {
     }
     sakuracloud = {
       source  = "sacloud/sakuracloud"
-      version = "2.14.0"
+      version = "2.25.0"
     }
   }
 }

--- a/src/terraform/docs/r/enhanced_db.md
+++ b/src/terraform/docs/r/enhanced_db.md
@@ -7,8 +7,11 @@ Manages a SakuraCloud sakuracloud_enhanced_db.
 ```tf
 resource "sakuracloud_enhanced_db" "foobar" {
   name            = "example"
-  database_name   = "example"
   password        = "your-password"
+  
+  database_name   = "example"
+  database_type   = "tidb"
+  region          = "is1"
 
   description = "..."
   tags        = ["...", "..."]
@@ -28,6 +31,9 @@ resource "sakuracloud_enhanced_db" "foobar" {
 * `name` - (Required) リソース名
 * `database_name` - (Required) データベース名
 * `password` - (Required) パスワード
+* `database_type` - (Required) データベースタイプ / この値は次のいずれかを指定［`tidb`/`mariadb`］/ この値を変更するとリソースの再作成が行われる
+* `region` - (Required) データベースを配置するリージョン / この値は次のいずれかを指定［`is1`/`tk1`］/ この値を変更するとリソースの再作成が行われる
+* `allowed_networks` - (Optional) A list of CIDR blocks allowed to connect.
 * `icon_id` - (Optional) The icon id to attach to the Enhanced Database.
 * `description` - (Optional) The description of the Enhanced Database. The length of this value must be in the range[`1`-`512`].
 * `tags` - (Optional) Any tags to assign to the Enhanced Database.
@@ -46,7 +52,5 @@ The `timeouts` block allows you to specify [timeouts](https://www.terraform.io/d
 ## Attribute Reference
 
 * `id` - The id of the sakuracloud_enhanced_db.
-* `database_type` - The type of database.
 * `hostname` - The name of database host. This will be built from `database_name` + `tidb-is1.db.sakurausercontent.com`.
 * `max_connections` - The value of max connections setting.
-* `region` - The region name.

--- a/src/terraform/docs/r/server.md
+++ b/src/terraform/docs/r/server.md
@@ -69,6 +69,7 @@ ACPIが利用できないサーバの場合`true`に設定する
     - `dedicatedcpu`: コア専有
 * `core` - (Optional) vCPUの割り当て数 / デフォルト:`1`
 * `memory` - (Optional) メモリサイズ(GiB単位) / デフォルト:`1`
+* `cpu_model` - (Optional) The model of CPU.
 * `gpu` - (Optional) GPUの割り当て数 
 * `network_interface` - (Optional) NIC設定のリスト。詳細は[network_interfaceブロック](#network_interface)を参照
 * `interface_driver` - (Optional) NICのドライバー / 次のいずれかを指定［`virtio`/`e1000`]/ デフォルト:`virtio`
@@ -76,7 +77,7 @@ ACPIが利用できないサーバの場合`true`に設定する
 
 !!! Note
     `core`と`memory`、`gpu`に指定できる値の組み合わせはさくらのクラウドドキュメントなどを参照ください。  
-    `usacloud server-plan ls`コマンドでも確認できます。
+    `usacloud server-plan ls`コマンドでも確認できます(`cpu_model`に指定できる値もこちらでご確認いただけます)。
 
 !!! Note
     `network_interface`は省略可能ですが、省略した場合NICが接続されていない状態のサーバが作成されます。  

--- a/src/terraform/mkdocs.yml
+++ b/src/terraform/mkdocs.yml
@@ -23,6 +23,9 @@ nav:
   - ホーム: index.md
   - ガイド:
     - アップグレードガイド:
+      - v2.25での変更点: guides/upgrade_to_v2.25.0.md
+      - v2.24での変更点: guides/upgrade_to_v2.24.0.md
+      - v2.23での変更点: guides/upgrade_to_v2.23.0.md
       - v2.22での変更点: guides/upgrade_to_v2.22.0.md
       - v2.21での変更点: guides/upgrade_to_v2.21.0.md
       - v2.20での変更点: guides/upgrade_to_v2.20.0.md


### PR DESCRIPTION
closes #193 
closes #198  
closes #200 

> [!Note]
> example中にterraform-provider-sakuracloudのバージョン指定を埋め込んでいるが、最新版のv2.25.1にはhttps://github.com/sacloud/terraform-provider-sakuracloud/issues/1131 の問題があるためv2.25.0を指定した。