### PR TITLE
http providerの非推奨になった属性を修正

### DIFF
--- a/src/terraform/docs/guides/public_key_from_github.md
+++ b/src/terraform/docs/guides/public_key_from_github.md
@@ -45,7 +45,7 @@ resource "sakuracloud_server" "example" {
 
   disk_edit_parameter {
     disable_pw_auth = true
-    ssh_keys        = split("\n", trimspace(data.http.key.body)) // Note: 複数の公開鍵が登録されている場合は改行で結合されている
+    ssh_keys        = split("\n", trimspace(data.http.key.response_body)) // Note: 複数の公開鍵が登録されている場合は改行で結合されている
   }
 }
 


### PR DESCRIPTION
bodyが非推奨になっておりterraform実行時に警告が表示されるため修正します。

https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http#body