### PR TITLE
間違ったリンクを修正

### DIFF
--- a/src/terraform-policy/docs/index.md
+++ b/src/terraform-policy/docs/index.md
@@ -12,7 +12,7 @@
 実行環境にOPAとConftestがインストールされていることが前提となります。
 
 - [https://www.openpolicyagent.org/docs/latest/#running-opa](https://www.openpolicyagent.org/docs/latest/#running-opa)
-- [https://www.conftest.dev/install/](https://www.openpolicyagent.org/docs/latest/#running-opa)
+- [https://www.conftest.dev/install/](https://www.conftest.dev/install/)
 
 ### ローカル環境での利用
 


### PR DESCRIPTION
## 概要
https://docs.usacloud.jp/terraform-policy/ の `https://www.conftest.dev/install/` についているリンクのURLが間違っていたので修正します。

## 動作確認
make preview-terraform-policy を実行後、ブラウザから確認が可能です。