### PR TITLE
portの設定はTCP/HTTP/HTTPSで可能とする

### DIFF
--- a/src/terraform/docs/d/gslb.md
+++ b/src/terraform/docs/d/gslb.md
@@ -55,7 +55,7 @@ data "sakuracloud_gslb" "foobar" {
 * `delay_loop` - チェック間隔秒数
 * `host_header` - HTTP/HTTPSチェック時に利用されるHostヘッダの値
 * `path` - HTTP/HTTPSチェック時に利用されるリクエストパス
-* `port` - TCPチェック時に利用されるポート番号
+* `port` - TCP/HTTP/HTTPSチェック時に利用されるポート番号
 * `protocol` - プロトコル。次のいずれかとなる［`http`/`https`/`tcp`/`ping`]
 * `status` - HTTP/HTTPSチェック時に利用されるレスポンスコード
 

--- a/src/terraform/docs/r/gslb.md
+++ b/src/terraform/docs/r/gslb.md
@@ -55,7 +55,7 @@ resource "sakuracloud_gslb" "foobar" {
 * `delay_loop` - (Optional) チェック間隔秒数 / `10`-`60`の範囲で指定
 * `host_header` - (Optional) HTTP/HTTPSチェック時に利用されるHostヘッダの値
 * `path` - (Optional) HTTP/HTTPSチェック時のリクエストパス
-* `port` - (Optional) TCPチェック時のポート番号
+* `port` - (Optional) TCP/HTTP/HTTPSチェック時のポート番号
 * `status` - (Optional) HTTP/HTTPSチェック時のレスポンスコード
 
 ##### serverブロック


### PR DESCRIPTION
https://github.com/sacloud/terraform-provider-sakuracloud/pull/1180 にて修正された件をドキュメントにも反映します。