### PR TITLE
make generateが失敗する問題の修正

### DIFF
--- a/src/usacloud/Makefile
+++ b/src/usacloud/Makefile
@@ -24,4 +24,4 @@ clean:
 	rm -rf site/*
 
 generate:
-	go run tools/*.go $(CURDIR)/scaffold
+	cd tools && go run *.go $(CURDIR)/scaffold


### PR DESCRIPTION
## 背景

`/src/usacloud` において `make generate` が正しく動作しませんでした。

```sh
$ go version
go version go1.23.0 linux/amd64

$ make generate 
go run tools/*.go /home/ubuntu/git/github.com/sacloud/docs.usacloud.jp/src/usacloud/scaffold
tools/gen-command-reference.go:8:2: no required module provides package github.com/sacloud/libsacloud/v2/sacloud: go.mod file not found in current directory or any parent directory; see 'go help modules'
tools/gen-command-reference.go:9:2: no required module provides package github.com/sacloud/libsacloud/v2/sacloud/profile: go.mod file not found in current directory or any parent directory; see 'go help modules'
tools/gen-command-reference.go:10:2: no required module provides package github.com/sacloud/usacloud/pkg/cli: go.mod file not found in current directory or any parent directory; see 'go help modules'
tools/gen-command-reference.go:11:2: no required module provides package github.com/sacloud/usacloud/pkg/cmd/core: go.mod file not found in current directory or any parent directory; see 'go help modules'
tools/gen-command-reference.go:12:2: no required module provides package github.com/sacloud/usacloud/pkg/config: go.mod file not found in current directory or any parent directory; see 'go help modules'
tools/gen-command-reference.go:13:2: no required module provides package github.com/sacloud/usacloud/pkg/test: go.mod file not found in current directory or any parent directory; see 'go help modules'
tools/gen-command-reference.go:14:2: no required module provides package github.com/sacloud/usacloud/tools: go.mod file not found in current directory or any parent directory; see 'go help modules'
make: *** [Makefile:27: generate] Error 1
```

## 変更点
おそらくGoのバージョン間の差異によるものだと思われます。
Makefile内でcdしてからgo runを実行するように変更しました。

## 動作確認

- [x] `make generate` コマンドが正常に動作することを確認