### PR TITLE
Terraform providerのAppRunのドキュメントを追加

### DIFF
--- a/src/terraform/docs/d/apprun_application.md
+++ b/src/terraform/docs/d/apprun_application.md
@@ -1,0 +1,64 @@
+# AppRun アプリケーション: sakuracloud_apprun_application
+
+AppRun アプリケーションの情報を参照するためのデータソース
+
+## Example Usage
+
+```tf
+data "sakuracloud_apprun_application" "foobar" {
+  name = "foobar"
+}
+```
+## Argument Reference
+
+* `name` - (Required) アプリケーション名
+
+## Attribute Reference
+
+* `id` - アプリケーションID
+* `timeout_seconds` - アプリケーションの公開URLにアクセスして、インスタンスが起動してからレスポンスが返るまでの時間制限
+* `port` - アプリケーションがリクエストを待ち受けるポート番号
+* `min_scale` - アプリケーション全体の最小スケール数
+* `max_scale` - アプリケーション全体の最大スケール数
+* `components` - アプリケーションのコンポーネント情報
+* `public_url` - 公開URL
+* `status` - アプリケーションステータス
+
+#### `components` ブロック
+
+* `name` - コンポーネント名
+* `max_cpu` - コンポーネントの最大CPU数
+* `max_memory` - コンポーネントの最大メモリ
+* `deploy_source` - コンポーネントを構成するソース
+* `env` - コンポーネントに渡す環境変数
+* `probe` - コンポーネントのプローブ設定
+
+#### `deploy_source` ブロック
+
+* `container_registry` - コンテナレジストリ
+
+#### `container_registry` ブロック
+
+* `image` - コンテナイメージ名
+* `server` - コンテナレジストリのサーバー名
+* `username` - コンテナレジストリの認証情報
+
+#### `env` ブロック
+
+* `key` - 環境変数名
+* `value` - 環境変数の値
+
+#### `probe` ブロック
+
+* `http_get` - HTTP GETプローブタイプ
+
+#### `http_get` ブロック
+
+* `path` - HTTPサーバーへアクセスしプローブをチェックする際のパス
+* `port` - HTTPサーバーへアクセスしプローブをチェックする際のポート番号
+* `headers` - HTTPサーバーへアクセスしプローブをチェックする際のヘッダー
+
+#### `headers` ブロック
+
+* `name` - ヘッダーフィールド名
+* `value` - ヘッダーフィールド値

--- a/src/terraform/docs/r/apprun_application.md
+++ b/src/terraform/docs/r/apprun_application.md
@@ -1,0 +1,134 @@
+# AppRun アプリケーション: sakuracloud_apprun_application
+
+## Example Usage
+
+```tf
+resource "sakuracloud_apprun_application" "foobar" {
+  name            = "foobar"
+  timeout_seconds = 60
+  port            = 80
+  min_scale       = 0
+  max_scale       = 1
+  components {
+    name       = "foobar"
+    max_cpu    = "0.1"
+    max_memory = "256Mi"
+    deploy_source {
+      container_registry {
+        image    = "foorbar.sakuracr.jp/foorbar:latest"
+        server   = "foorbar.sakuracr.jp"
+        username = "user"
+        password = "password"
+      }
+    }
+    env {
+      key   = "key"
+      value = "value"
+    }
+    env {
+      key   = "key2"
+      value = "value2"
+    }
+    env {
+      key   = "key3"
+      value = "value3"
+    }
+    probe {
+      http_get {
+        path = "/"
+        port = 80
+        headers {
+          name  = "name"
+          value = "value"
+        }
+        headers {
+          name  = "name2"
+          value = "value2"
+        }
+      }
+    }
+  }
+  traffics {
+    version_index = 0
+    percent       = 100
+  }
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) アプリケーション名
+* `timeout_seconds` - (Required) アプリケーションの公開URLにアクセスして、インスタンスが起動してからレスポンスが返るまでの時間制限
+* `port` - (Required) アプリケーションがリクエストを待ち受けるポート番号
+* `min_scale` - (Required) アプリケーション全体の最小スケール数
+* `max_scale` - (Required) アプリケーション全体の最大スケール数
+* `components` - (Required) アプリケーションのコンポーネント情報
+* `traffics` - (Optional) アプリケーションのトラフィック情報
+
+#### `components` ブロック
+
+* `name` - (Required) コンポーネント名
+* `max_cpu` - (Required) コンポーネントの最大CPU数 / 次のいずれかを指定［`0.1`/`0.2`/`0.3`/`0.4`/`0.5`/`0.6`/`0.7`/`0.8`/`0.9`/`1`］
+* `max_memory` - (Required) コンポーネントの最大メモリ / 次のいずれかを指定［`256Mi`/`512Mi`/`1Gi`/`2Gi`］
+* `deploy_source` - (Required) コンポーネントを構成するソース
+* `env` - (Optional) コンポーネントに渡す環境変数
+* `probe` - (Optional) コンポーネントのプローブ設定
+
+#### `deploy_source` ブロック
+
+* `container_registry` - (Optional) コンテナレジストリ
+
+#### `container_registry` ブロック
+
+* `image` - (Required) コンテナイメージ名
+* `server` - (Optional) コンテナレジストリのサーバー名
+* `username` - (Optional) コンテナレジストリの認証情報
+* `password` - (Optional) コンテナレジストリの認証情報
+
+#### `env` ブロック
+
+* `key` - (Optional) 環境変数名
+* `value` - (Optional) 環境変数の値
+
+#### `probe` ブロック
+
+* `http_get` - (Required) HTTP GETプローブタイプ
+
+#### `http_get` ブロック
+
+* `path` - (Required) HTTPサーバーへアクセスしプローブをチェックする際のパス
+* `port` - (Required) HTTPサーバーへアクセスしプローブをチェックする際のポート番号
+* `headers` - (Optional) HTTPサーバーへアクセスしプローブをチェックする際のヘッダー
+
+#### `headers` ブロック
+
+* `name` - (Optional) ヘッダーフィールド名
+* `value` - (Optional) ヘッダーフィールド値
+
+#### `traffics` ブロック
+
+!!! Note
+    アプリケーションを作成、更新した際、その設定情報をバージョンとして保存します。version_index は作成日時で降順にソートされたバージョンのリストのインデックスを指定します。例えばバージョンが3つある場合 `version_index = 0` は最新のバージョンを指し、`version_index = 2` は最も古いバージョンを指します。
+
+* `version_index` - (Required) アプリケーションバージョンのインデックス
+* `percent` - (Required) トラフィック分散の割合
+
+### Timeouts
+
+timeoutsブロックで[カスタムタイムアウト](https://www.terraform.io/docs/configuration/resources.html#operation-timeouts)が設定可能です。
+
+* `create` - 作成 (デフォルト: 5分)
+* `update` - 更新 (デフォルト: 5分)
+* `delete` - 削除 (デフォルト: 20分)
+
+## Attribute Reference
+
+* `id` - AppRun アプリケーションのID
+
+## Import
+
+IDを指定する事でインポート可能です。
+
+```bash
+$ terraform import sakuracloud_apprun_application.example 123456789012
+```

--- a/src/terraform/mkdocs.yml
+++ b/src/terraform/mkdocs.yml
@@ -50,8 +50,8 @@ nav:
       - v2.1での変更点: guides/upgrade_to_v2.1.0.md
       - v2.0での変更点: guides/upgrade_to_v2.0.0.md
     - その他ガイド:
-        - オブジェクトストレージ: guides/object_storage.md
-        - GitHubからの公開鍵取得: guides/public_key_from_github.md
+      - オブジェクトストレージ: guides/object_storage.md
+      - GitHubからの公開鍵取得: guides/public_key_from_github.md
   - 設定リファレンス:
     - プロバイダ設定: provider.md
     - プロバイダデータソース:
@@ -121,7 +121,7 @@ nav:
         - シンプル監視: r/simple_monitor.md
     - セキュアモバイル:
       - リソース:
-        - モバイルゲートウェイ : r/mobile_gateway.md
+        - モバイルゲートウェイ: r/mobile_gateway.md
         - SIM: r/sim.md
     - SMS:
       - データソース:
@@ -139,14 +139,14 @@ nav:
         - エンハンスドデータベース: r/enhanced_db.md
     - ウェブアクセラレータ:
         - データソース:
-            - サイト情報: d/webaccel.md
+          - サイト情報: d/webaccel.md
         - リソース:
-            - 証明書: r/webaccel_certificate.md
+          - 証明書: r/webaccel_certificate.md
     - AppRun:
         - データソース:
-            - アプリケーション: d/apprun_application.md
+          - アプリケーション: d/apprun_application.md
         - リソース:
-            - アプリケーション: r/apprun_application.md
+          - アプリケーション: r/apprun_application.md
     - その他:
       - データソース:
         - アイコン: d/icon.md

--- a/src/terraform/mkdocs.yml
+++ b/src/terraform/mkdocs.yml
@@ -142,6 +142,11 @@ nav:
             - サイト情報: d/webaccel.md
         - リソース:
             - 証明書: r/webaccel_certificate.md
+    - AppRun:
+        - データソース:
+            - アプリケーション: d/apprun_application.md
+        - リソース:
+            - アプリケーション: r/apprun_application.md
     - その他:
       - データソース:
         - アイコン: d/icon.md


### PR DESCRIPTION
## 背景
https://github.com/sacloud/terraform-provider-sakuracloud/pull/1200 にてTerraform providerに `sakuracloud_apprun_application  resource/data source` の追加を行いました。
これに伴って、Terraformのドキュメントを追加します。

ℹ️ なお、コードジェネレーターに関しては準備が整っていないので、このPRでは追加しませんでした。後追いで対応します。

## 変更点

- `sakuracloud_apprun_application  resource/data source` のドキュメントを追加

## 動作確認

- `make preview-terraform` でサーバーを起動
- [x] 以下のページにアクセスして、正しくドキュメントが表示されることを確認
  - http://0.0.0.0:8080/terraform/d/apprun_application/
  - http://0.0.0.0:8080/terraform/r/apprun_application/
- [x] メニューバーにAppRunが追加されていることを確認
  - <img width="430" alt="スクリーンショット 2024-12-12 19 07 28" src="https://github.com/user-attachments/assets/8df5bc3b-6327-412e-912f-5dd186e64199" />
