### PR TITLE
Terraform provider v2.26.0

### DIFF
--- a/src/terraform/docs/guides/upgrade_to_v2.26.0.md
+++ b/src/terraform/docs/guides/upgrade_to_v2.26.0.md
@@ -1,0 +1,107 @@
+# アップグレードガイド(v2.26)
+
+## 目次
+
+- [sakuracloud_disk: ディスク暗号化機能](#diff1)
+- [sakuracloud_webaccel_acl: ウェブアクセラレータ ACL機能](#diff2)
+- [sakuracloud_apprun_application: AppRun Application機能](#diff3)
+
+### sakuracloud_disk: ディスク暗号化機能 {: #diff1 }
+
+ディスク暗号化機能に対応しました。
+
+```hcl
+resource "sakuracloud_disk" "foobar" {
+  name              = "foobar"
+  plan              = "ssd"
+  connector         = "virtio"
+  size              = 20
+  source_archive_id = data.sakuracloud_archive.ubuntu.id
+  #distant_from      = ["111111111111"]
+  encryption_algorithm = "aes256_xts"
+
+  description = "description"
+  tags        = ["tag1", "tag2"]
+}
+```
+
+### sakuracloud_webaccel_acl: ウェブアクセラレータ ACL機能 {: #diff2 }
+
+ウェブアクセラレータのACLをコントロールするためのsakuracloud_webaccel_acl resource/data sourceを追加しました。
+
+```hcl
+data sakuracloud_webaccel "site" {
+  name = "your-site-name"
+}
+
+resource sakuracloud_webaccel_acl "acl" {
+  site_id = data.sakuracloud_webaccel.site.id
+
+  acl = join("\n", [
+    "deny 192.0.2.5/25",
+    "deny 198.51.100.0",
+    "allow all",
+  ])
+}
+```
+
+### sakuracloud_apprun_application: AppRun Application機能 {: #diff3 }
+
+AppRunをコントロールするためのsakuracloud_apprun_application resource/data sourceを追加しました。
+
+```hcl
+data "sakuracloud_apprun_application" "foobar" {
+  name = "foobar"
+}
+
+resource "sakuracloud_apprun_application" "foobar" {
+  name            = "foobar"
+  timeout_seconds = 60
+  port            = 80
+  min_scale       = 0
+  max_scale       = 1
+  components {
+    name       = "foobar"
+    max_cpu    = "0.1"
+    max_memory = "256Mi"
+    deploy_source {
+      container_registry {
+        image    = "foorbar.sakuracr.jp/foorbar:latest"
+        server   = "foorbar.sakuracr.jp"
+        username = "user"
+        password = "password"
+      }
+    }
+    env {
+      key   = "key"
+      value = "value"
+    }
+    env {
+      key   = "key2"
+      value = "value2"
+    }
+    env {
+      key   = "key3"
+      value = "value3"
+    }
+    probe {
+      http_get {
+        path = "/"
+        port = 80
+        headers {
+          name  = "name"
+          value = "value"
+        }
+        headers {
+          name  = "name2"
+          value = "value2"
+        }
+      }
+    }
+  }
+  traffics {
+    version_index = 0
+    percent       = 100
+  }
+}
+```

--- a/src/terraform/docs/index.md
+++ b/src/terraform/docs/index.md
@@ -30,7 +30,7 @@ terraform {
 
       # We recommend pinning to the specific version of the SakuraCloud Provider you're using
       # since new versions are released frequently
-      version = "2.25.0"
+      version = "2.26.0"
       #version = "~> 2"
     }
   }

--- a/src/terraform/docs/provider.md
+++ b/src/terraform/docs/provider.md
@@ -13,7 +13,7 @@ terraform {
 
       # We recommend pinning to the specific version of the SakuraCloud Provider you're using
       # since new versions are released frequently
-      version = "2.25.0"
+      version = "2.26.0"
       #version = "~> 2"
     }
   }

--- a/src/terraform/docs/r/certificate_authority.md
+++ b/src/terraform/docs/r/certificate_authority.md
@@ -11,7 +11,7 @@ terraform {
     }
     sakuracloud = {
       source  = "sacloud/sakuracloud"
-      version = "2.25.0"
+      version = "2.26.0"
     }
   }
 }

--- a/src/terraform/mkdocs.yml
+++ b/src/terraform/mkdocs.yml
@@ -23,6 +23,7 @@ nav:
   - ホーム: index.md
   - ガイド:
     - アップグレードガイド:
+      - v2.26での変更点: guides/upgrade_to_v2.26.0.md
       - v2.25での変更点: guides/upgrade_to_v2.25.0.md
       - v2.24での変更点: guides/upgrade_to_v2.24.0.md
       - v2.23での変更点: guides/upgrade_to_v2.23.0.md


### PR DESCRIPTION
fix https://github.com/sacloud/docs.usacloud.jp/issues/226

terraform-provider-sakuracloud のv2.26.0をリリースしましたので、それに合わせてバージョン番号を書き換えました。

