### PR TITLE
sakuracloud_diskのencryption_algorithmの対応を反映

### DIFF
--- a/src/terraform/docs/d/disk.md
+++ b/src/terraform/docs/d/disk.md
@@ -42,6 +42,7 @@ data "sakuracloud_disk" "foobar" {
 * `id` - ID
 * `connector` - ディスク接続インターフェース。 次のいずれかとなる［`virtio`/`ide`]
 * `description` - 説明
+* `encryption_algorithm` - ディスク暗号化アルゴリズム。 次のいずれかとなる［`none`/`aes256_xts`]
 * `icon_id` - アイコンID
 * `name` - 名称
 * `plan` - プラン。 次のいずれかとなる［`ssd`/`hdd`]

--- a/src/terraform/docs/r/disk.md
+++ b/src/terraform/docs/r/disk.md
@@ -14,6 +14,7 @@ resource "sakuracloud_disk" "foobar" {
   size              = 20
   source_archive_id = data.sakuracloud_archive.ubuntu.id
   #distant_from      = ["111111111111"]
+  encryption_algorithm = "aes256_xts"
 
   description = "description"
   tags        = ["tag1", "tag2"]
@@ -39,6 +40,7 @@ resource "sakuracloud_disk" "foobar" {
 * `plan` - (Optional) ディスクプラン / 次のいずれかを指定［`ssd`/`hdd`]/ この値を変更するとリソースの再作成が行われる / デフォルト:`ssd`
 * `size` - (Optional) サイズ(GiB単位) / この値を変更するとリソースの再作成が行われる / デフォルト:`20`
 * `distant_from` - (Optional) 別のストレージに格納する対象となるディスクのIDのリスト / この値を変更するとリソースの再作成が行われる
+* `encryption_algorithm` - (Optional) ディスク暗号化アルゴリズム / 次のいずれかを指定［`none`/`aes256_xts`]/ この値を変更するとリソースの再作成が行われる / デフォルト:`none`
 
 !!! Note
     1TB以上のサイズを指定する場合、`size`に1024の倍数を指定してください。  


### PR DESCRIPTION
## 背景
https://github.com/sacloud/terraform-provider-sakuracloud/pull/1161
https://github.com/sacloud/terraform-provider-sakuracloud/pull/1165
https://github.com/sacloud/terraform-provider-sakuracloud/pull/1167

sakuracloud_diskにて `encryption_algorithm` の対応がされたため、ドキュメントに反映します。

## 変更点
sakuracloud_diskのresource/data sourceのドキュメントに `encryption_algorithm` の反映をしました。

