### PR TITLE
sakuracloud_apprun_application resource/data sourceにコードエディタを追加

### DIFF
--- a/src/terraform/docs/d/apprun_application.md
+++ b/src/terraform/docs/d/apprun_application.md
@@ -9,6 +9,15 @@ data "sakuracloud_apprun_application" "foobar" {
   name = "foobar"
 }
 ```
+
+<div class="editor">
+
+<h2><a href="https://zouen-alpha.usacloud.jp/#data/apprun_application" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
+
+<iframe src="https://zouen-alpha.usacloud.jp/#data/apprun_application"></iframe>
+
+</div>
+
 ## Argument Reference
 
 * `name` - (Required) アプリケーション名

--- a/src/terraform/docs/r/apprun_application.md
+++ b/src/terraform/docs/r/apprun_application.md
@@ -55,6 +55,14 @@ resource "sakuracloud_apprun_application" "foobar" {
 }
 ```
 
+<div class="editor">
+
+<h2><a href="https://zouen-alpha.usacloud.jp/#resource/apprun_application" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
+
+<iframe src="https://zouen-alpha.usacloud.jp/#resource/apprun_application"></iframe>
+
+</div>
+
 ## Argument Reference
 
 * `name` - (Required) アプリケーション名


### PR DESCRIPTION
## 背景
zouen-alpha.usacloud.jpにsakuracloud_apprun_application resource/data sourceの取り込みが完了したため、ドキュメント上のコードエディタとして追加します。

## 変更点
sakuracloud_apprun_application resource/data sourceにコードエディタを追加

## 動作確認
- [x] `make preview-terraform` でサーバーを起動して、正しくページが表示されることを確認
- [x] CIが通ることを確認