### PR TITLE
homebrewでのusacloudインストール方法を追加

### DIFF
--- a/src/usacloud/docs/installation/start_guide.md
+++ b/src/usacloud/docs/installation/start_guide.md
@@ -10,6 +10,12 @@
 curl -fsSL https://github.com/sacloud/usacloud/releases/latest/download/install.sh | bash
 ```
 
+#### macOS/Linux (Homebrew)
+
+```bash
+brew tap sacloud/usacloud; brew install usacloud
+```
+
 ---
 
 #### Windows(`chocolatey`)


### PR DESCRIPTION
https://knowledge.sakura.ad.jp/10875/ で紹介されています
linux, macosとも動作しました