### PR TITLE
シンプルMQを追加

### DIFF
--- a/src/terraform/docs/d/simple_mq.md
+++ b/src/terraform/docs/d/simple_mq.md
@@ -1,0 +1,29 @@
+# シンプルMQ: sakuracloud_simple_mq
+
+シンプルMQの情報を参照するためのデータソース
+
+## Example Usage
+
+```tf
+data "sakuracloud_simple_mq" "foobar" {
+  name = "foobar"
+}
+```
+
+## Argument Reference
+
+nameもしくはtagsのいずれかを指定し、当てはまるキューが一意に定まる必要があります。
+
+* `name` - (Optional) キュー名
+* `tags` - (Optional) 対象リソースが持つタグ。指定値と完全一致するリソースが参照対象となる。複数指定した場合はAND条件となる
+
+## Attribute Reference
+
+* `id` - ID
+* `name` - キュー名
+* `visibility_timeout_seconds` - 可視性タイムアウトの秒数
+* `expire_seconds` - 未処理メッセージ保存期間の秒数
+* `description` - 説明
+* `tags` - タグ
+* `icon_id` - アイコンID
+

--- a/src/terraform/docs/r/simple_mq.md
+++ b/src/terraform/docs/r/simple_mq.md
@@ -1,0 +1,32 @@
+# シンプルMQ: sakuracloud_simple_mq
+
+!!! warning
+    キューのAPIキーの発行はterraformでは行えません。
+    発行するには、[さくらのクラウドコントロールパネル](https://secure.sakura.ad.jp/cloud/)や[さくらのクラウドAPI](https://manual.sakura.ad.jp/api/cloud/simplemq/sacloud/#operation/rotateAPIKey)を利用してください。
+
+## Example Usage
+
+```hcl
+resource "sakuracloud_simple_mq" "foobar" {
+  name        = "foobar"
+  description = "description"
+  tags        = ["tag1", "tag2"]
+
+  visibility_timeout_seconds = 30
+  expire_seconds             = 345600
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) キュー名
+* `visibility_timeout_seconds` - (Optional) 可視性タイムアウトの秒数
+* `expire_seconds` - (Optional) 未処理メッセージ保存期間の秒数
+* `description` - (Optional) 説明
+* `tags` - (Optional) タグ
+* `icon_id` - (Optional) アイコンID
+
+## Attribute Reference
+
+* `id` - ID
+

--- a/src/terraform/mkdocs.yml
+++ b/src/terraform/mkdocs.yml
@@ -114,6 +114,7 @@ nav:
         - GSLB: d/gslb.md
         - エンハンスドロードバランサ: d/proxylb.md
         - シンプル監視: d/simple_monitor.md
+        - シンプルMQ: d/simple_mq.md
       - リソース:
         - コンテナレジストリ: r/container_registry.md
         - DNS: r/dns.md
@@ -122,6 +123,7 @@ nav:
         - エンハンスドロードバランサ: r/proxylb.md
         - エンハンスドロードバランサ(ACME設定): r/proxylb_acme.md
         - シンプル監視: r/simple_monitor.md
+        - シンプルMQ: r/simple_mq.md
     - セキュアモバイル:
       - リソース:
         - モバイルゲートウェイ: r/mobile_gateway.md


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

no issue

### このPRはどういう変更を行いますか？

https://github.com/sacloud/terraform-provider-sakuracloud/pull/1256 にてシンプルMQのterraform providerへの追加を行っているため、こちらのドキュメントに追加内容を同期します。

### ドキュメントの変更は必要ですか？
はい

#### 変更内容

`make preview-terraform` でサーバーを起動
「グローバル」以下にシンプルMQのdata sourceとresourceのドキュメントが追加される
- http://127.0.0.1:8080/terraform/d/simple_mq/
<img width="1632" alt="Screenshot 2025-06-12 at 18 27 57" src="https://github.com/user-attachments/assets/70dcdcd4-c2df-4441-8f62-eaf1b1216492" />


- http://127.0.0.1:8080/terraform/r/simple_mq/
<img width="1632" alt="Screenshot 2025-06-12 at 18 28 06" src="https://github.com/user-attachments/assets/4138ac47-1cca-497d-9db8-d362358a41b4" />
