### PR TITLE
webaccel{,_certificate}: オリジンガードトークン、Let's Encrypt設定のドキュメント追加

### DIFF
--- a/src/terraform/docs/r/webaccel.md
+++ b/src/terraform/docs/r/webaccel.md
@@ -76,6 +76,12 @@ resource "sakuracloud_webaccel" "foobar" {
 
 ---
 
+`origin_guard_token` ブロックは以下の引数を指定可能。
+
+* `rotate` - トークンを即時更新したい場合に指定するフラグ。新規作成時には`true`を指定できない。デフォルトで`false`。
+
+---
+
 `logging` ブロックは以下の引数を設定可能。
 
 * `s3_bucket_name` - ログ保管先のバケット名 / さくらのオブジェクトストレージのバケットを指定する必要がある
@@ -109,6 +115,12 @@ resource "sakuracloud_webaccel" "foobar" {
 * `s3_secret_access_key` - バケットへの接続で利用するS3シークレットアクセスキー
 * `s3_doc_index` - ドキュメントインデクスの有効・無効を表すフラグ
 
+---
+
+`origin_guard_token` ブロックは以下の属性値をサポートする。
+
+* `token` - オリジンガードトークンの値。
+* `rotate` - トークンを即時更新するフラグ。デフォルトで`false`。
 
 ---
 

--- a/src/terraform/docs/r/webaccel_certificate.md
+++ b/src/terraform/docs/r/webaccel_certificate.md
@@ -27,8 +27,9 @@ resource sakuracloud_webaccel_certificate "foobar" {
 ## Argument Reference
 
 * `site_id` - (Required) サイトのID
-* `private_key` - (Required) 秘密鍵
-* `certificate_chain` - (Required) 公開鍵
+* `private_key` - (Optional) 秘密鍵。`certificate_chain`と共に使用する。`lets_encrypt`と同時には指定できない。
+* `certificate_chain` - (Optional) サイトの証明書チェーン。`private_key`と共に使用する。`lets_encrypt`と同時には指定できない。
+* `lets_encrypt` - (Optional) Let's Encrypt証明書の自動更新を有効化するフラグ。`true`以外の値をサポートしない。`private_key`または`certificate_chain`とは同時に指定できない。
 
 ## Attribute Reference
 


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

[こちらのイシュー](https://github.com/sacloud/docs.usacloud.jp/issues/240#issue-3148437968)に付随する記事追加であるため、このリポジトリではイシューを立てていません。

関連イシュー: https://github.com/sacloud/terraform-provider-sakuracloud/issues/1258

### このPRはどういう変更を行いますか？

resource_sakuracloud_webaccel: オリジンガードトークン用のブロックのドキュメントを追加します
resource_sakuracloud_webaccel_certificate: Let's Encrypt自動更新フラグを追加、他のフィールドのドキュメントを一部更新します。

### ドキュメントの変更は必要ですか？

ドキュメントの更新です。