### PR TITLE
docs: remove readwrite from container-registry access-level options

### DIFF
--- a/src/terraform/docs/d/container_registry.md
+++ b/src/terraform/docs/d/container_registry.md
@@ -41,7 +41,7 @@ data "sakuracloud_container_registry" "foobar" {
 
 * `id` - ID
 * `access_level` - アクセスレベル。ユーザーがコンテナレジストリにアクセスできる操作のレベルを表す  
-次のいずれかの値となる。[`readwrite`/`readonly`/`none`]
+次のいずれかの値となる。[`readonly`/`none`]
 * `description` - 説明
 * `fqdn` - コンテナレジストリにアクセスするためのFQDN
 * `icon_id` - アイコンID

--- a/src/terraform/docs/r/container_registry.md
+++ b/src/terraform/docs/r/container_registry.md
@@ -27,7 +27,7 @@ resource "sakuracloud_container_registry" "foobar" {
   name            = "foobar"
   virtual_domain  = "your-domain.example.com"
   subdomain_label = "your-subdomain-label"
-  access_level    = "readwrite" # this must be one of ["readwrite"/"readonly"/"none"]
+  access_level    = "readonly" # this must be one of ["readonly"/"none"]
 
   description = "description"
   tags        = ["tag1", "tag2"]
@@ -55,7 +55,7 @@ resource "sakuracloud_container_registry" "foobar" {
 ## Argument Reference
 
 * `name` - (Required) 名前 / `1`-`64`文字で指定
-* `access_level` - (Required) アクセスレベル / この値は次のいずれかを指定［`readwrite`/`readonly`/`none`]
+* `access_level` - (Required) アクセスレベル / この値は次のいずれかを指定［`readonly`/`none`]
 * `subdomain_label` - (Required) サブドメインラベル /  `1`-`64`文字で指定 / この値を変更するとリソースの再作成が行われる
 * `user` - (Optional) ユーザー設定のリスト。詳細は[userブロック](#user)を参照
 * `virtual_domain` - (Optional) 独自ドメイン(FQDN)

--- a/src/usacloud/docs/references/container-registry.md
+++ b/src/usacloud/docs/references/container-registry.md
@@ -70,7 +70,7 @@ Flags:
 
   === Container-Registry-specific options ===
 
-      --access-level string      (*required) options: [readwrite/readonly/none]
+      --access-level string      (*required) options: [readonly/none]
       --subdomain-label string   (*required) 
       --users string             
       --virtual-domain string    
@@ -105,7 +105,7 @@ Flags:
         "tag2=example2"
     ],
     "IconID": 123456789012,
-    "AccessLevel": "readwrite | readonly | none",
+    "AccessLevel": "readonly | none",
     "SubDomainLabel": "your-sub-domain",
     "VirtualDomain": "your-domain.example.com",
     "Users": [
@@ -169,7 +169,7 @@ Flags:
 
   === Container-Registry-specific options ===
 
-      --access-level string      options: [readwrite/readonly/none]
+      --access-level string      options: [readonly/none]
       --subdomain-label string   
       --users string             
       --virtual-domain string    
@@ -204,7 +204,7 @@ Flags:
         "tag2=example2"
     ],
     "IconID": 123456789012,
-    "AccessLevel": "readwrite | readonly | none",
+    "AccessLevel": "readonly | none",
     "SubDomainLabel": "your-sub-domain",
     "VirtualDomain": "your-domain.example.com",
     "Users": [


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

issueなし

### このPRはどういう変更を行いますか？

コンテナレジストリのアクセスレベルオプションから `readwrite` を削除し、`readonly` と `none` のみを有効な値として記載するようにドキュメントを更新した。

対象ドキュメント:
- Terraform Provider: `container_registry` データソースおよびリソース
- Usacloud: `container-registry` コマンドリファレンス

### ドキュメントの変更は必要ですか？

このPR自体がドキュメントの修正であるため不要