### PR TITLE
docs: remove zouen-alpha code editor embeds from terraform docs

### DIFF
--- a/src/terraform/docs/d/apprun_application.md
+++ b/src/terraform/docs/d/apprun_application.md
@@ -10,13 +10,6 @@ data "sakuracloud_apprun_application" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#data/apprun_application" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#data/apprun_application"></iframe>
-
-</div>
 
 ## Argument Reference
 

--- a/src/terraform/docs/d/archive.md
+++ b/src/terraform/docs/d/archive.md
@@ -10,13 +10,6 @@ data "sakuracloud_archive" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#data/archive" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#data/archive"></iframe>
-
-</div>
 
 ## Argument Reference
 

--- a/src/terraform/docs/d/auto_scale.md
+++ b/src/terraform/docs/d/auto_scale.md
@@ -12,13 +12,6 @@ data "sakuracloud_auto_scale" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#data/auto_scale" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#data/auto_scale"></iframe>
-
-</div>
 
 ## Argument Reference
 

--- a/src/terraform/docs/d/bridge.md
+++ b/src/terraform/docs/d/bridge.md
@@ -12,13 +12,6 @@ data "sakuracloud_bridge" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#data/bridge" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#data/bridge"></iframe>
-
-</div>
 
 ## Argument Reference
 

--- a/src/terraform/docs/d/cdrom.md
+++ b/src/terraform/docs/d/cdrom.md
@@ -15,13 +15,6 @@ data "sakuracloud_cdrom" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#data/cdrom" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#data/cdrom"></iframe>
-
-</div>
 
 ## Argument Reference
 

--- a/src/terraform/docs/d/certificate_authority.md
+++ b/src/terraform/docs/d/certificate_authority.md
@@ -12,13 +12,6 @@ data "sakuracloud_certificate_authority" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#data/certificate_authority" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#data/certificate_authority"></iframe>
-
-</div>
 
 ## Argument Reference
 

--- a/src/terraform/docs/d/container_registry.md
+++ b/src/terraform/docs/d/container_registry.md
@@ -12,13 +12,6 @@ data "sakuracloud_container_registry" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#data/container_registry" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#data/container_registry"></iframe>
-
-</div>
 
 ## Argument Reference
 

--- a/src/terraform/docs/d/database.md
+++ b/src/terraform/docs/d/database.md
@@ -12,13 +12,6 @@ data "sakuracloud_database" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#data/database" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#data/database"></iframe>
-
-</div>
 
 ## Argument Reference
 

--- a/src/terraform/docs/d/disk.md
+++ b/src/terraform/docs/d/disk.md
@@ -12,13 +12,6 @@ data "sakuracloud_disk" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#data/disk" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#data/disk"></iframe>
-
-</div>
 
 ## Argument Reference
 

--- a/src/terraform/docs/d/dns.md
+++ b/src/terraform/docs/d/dns.md
@@ -12,13 +12,6 @@ data "sakuracloud_dns" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#data/dns" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#data/dns"></iframe>
-
-</div>
 
 
 ## Argument Reference

--- a/src/terraform/docs/d/enhanced_db.md
+++ b/src/terraform/docs/d/enhanced_db.md
@@ -20,13 +20,6 @@ data "sakuracloud_enhanced_db" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#data/enhanced_db" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#data/enhanced_db"></iframe>
-
-</div>
 
 
 ## Argument Reference

--- a/src/terraform/docs/d/esme.md
+++ b/src/terraform/docs/d/esme.md
@@ -12,13 +12,6 @@ data "sakuracloud_esme" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#data/esme" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#data/esme"></iframe>
-
-</div>
 
 ## Argument Reference
 

--- a/src/terraform/docs/d/gslb.md
+++ b/src/terraform/docs/d/gslb.md
@@ -12,13 +12,6 @@ data "sakuracloud_gslb" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#data/gslb" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#data/gslb"></iframe>
-
-</div>
 
 
 ## Argument Reference

--- a/src/terraform/docs/d/icon.md
+++ b/src/terraform/docs/d/icon.md
@@ -12,13 +12,6 @@ data "sakuracloud_icon" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#data/icon" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#data/icon"></iframe>
-
-</div>
 
 
 ## Argument Reference

--- a/src/terraform/docs/d/internet.md
+++ b/src/terraform/docs/d/internet.md
@@ -12,13 +12,6 @@ data "sakuracloud_internet" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#data/internet" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#data/internet"></iframe>
-
-</div>
 
 
 ## Argument Reference

--- a/src/terraform/docs/d/load_balancer.md
+++ b/src/terraform/docs/d/load_balancer.md
@@ -12,13 +12,6 @@ data "sakuracloud_load_balancer" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#data/load_balancer" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#data/load_balancer"></iframe>
-
-</div>
 
 
 ## Argument Reference

--- a/src/terraform/docs/d/local_router.md
+++ b/src/terraform/docs/d/local_router.md
@@ -12,13 +12,6 @@ data "sakuracloud_local_router" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#data/local_router" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#data/local_router"></iframe>
-
-</div>
 
 
 ## Argument Reference

--- a/src/terraform/docs/d/nfs.md
+++ b/src/terraform/docs/d/nfs.md
@@ -12,13 +12,6 @@ data "sakuracloud_nfs" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#data/nfs" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#data/nfs"></iframe>
-
-</div>
 
 
 ## Argument Reference

--- a/src/terraform/docs/d/note.md
+++ b/src/terraform/docs/d/note.md
@@ -12,13 +12,6 @@ data "sakuracloud_note" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#data/note" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#data/note"></iframe>
-
-</div>
 
 
 ## Argument Reference

--- a/src/terraform/docs/d/packet_filter.md
+++ b/src/terraform/docs/d/packet_filter.md
@@ -12,13 +12,6 @@ data "sakuracloud_packet_filter" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#data/packet_filter" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#data/packet_filter"></iframe>
-
-</div>
 
 
 ## Argument Reference

--- a/src/terraform/docs/d/private_host.md
+++ b/src/terraform/docs/d/private_host.md
@@ -12,13 +12,6 @@ data "sakuracloud_private_host" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#data/private_host" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#data/private_host"></iframe>
-
-</div>
 
 
 ## Argument Reference

--- a/src/terraform/docs/d/proxylb.md
+++ b/src/terraform/docs/d/proxylb.md
@@ -12,13 +12,6 @@ data "sakuracloud_proxylb" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#data/proxylb" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#data/proxylb"></iframe>
-
-</div>
 
 
 ## Argument Reference

--- a/src/terraform/docs/d/server.md
+++ b/src/terraform/docs/d/server.md
@@ -12,13 +12,6 @@ data "sakuracloud_server" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#data/server" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#data/server"></iframe>
-
-</div>
 
 ## Argument Reference
 

--- a/src/terraform/docs/d/server_vnc_info.md
+++ b/src/terraform/docs/d/server_vnc_info.md
@@ -10,13 +10,6 @@ data "sakuracloud_server_vnc_info" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#data/server_vnc_info" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#data/server_vnc_info"></iframe>
-
-</div>
 
 ## Argument Reference
 

--- a/src/terraform/docs/d/simple_monitor.md
+++ b/src/terraform/docs/d/simple_monitor.md
@@ -12,13 +12,6 @@ data "sakuracloud_simple_monitor" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#data/simple_monitor" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#data/simple_monitor"></iframe>
-
-</div>
 
 
 ## Argument Reference

--- a/src/terraform/docs/d/ssh_key.md
+++ b/src/terraform/docs/d/ssh_key.md
@@ -12,13 +12,6 @@ data "sakuracloud_ssh_key" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#data/ssh_key" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#data/ssh_key"></iframe>
-
-</div>
 
 
 ## Argument Reference

--- a/src/terraform/docs/d/subnet.md
+++ b/src/terraform/docs/d/subnet.md
@@ -12,13 +12,6 @@ data sakuracloud_subnet "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#data/subnet" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#data/subnet"></iframe>
-
-</div>
 
 
 ## Argument Reference

--- a/src/terraform/docs/d/switch.md
+++ b/src/terraform/docs/d/switch.md
@@ -12,13 +12,6 @@ data "sakuracloud_switch" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#data/switch" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#data/switch"></iframe>
-
-</div>
 
 
 ## Argument Reference

--- a/src/terraform/docs/d/vpc_router.md
+++ b/src/terraform/docs/d/vpc_router.md
@@ -12,13 +12,6 @@ data "sakuracloud_vpc_router" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#data/vpc_router" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#data/vpc_router"></iframe>
-
-</div>
 
 ## Argument Reference
 

--- a/src/terraform/docs/d/webaccel.md
+++ b/src/terraform/docs/d/webaccel.md
@@ -13,13 +13,6 @@ data sakuracloud_webaccel "site" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#data/webaccel" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#data/webaccel"></iframe>
-
-</div>
 
 
 ## Argument Reference

--- a/src/terraform/docs/d/zone.md
+++ b/src/terraform/docs/d/zone.md
@@ -14,13 +14,6 @@ data "sakuracloud_zone" "is1a" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#data/zone" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#data/zone"></iframe>
-
-</div>
 
 
 ## Argument Reference

--- a/src/terraform/docs/r/apprun_application.md
+++ b/src/terraform/docs/r/apprun_application.md
@@ -63,13 +63,6 @@ resource "sakuracloud_apprun_application" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#resource/apprun_application" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#resource/apprun_application"></iframe>
-
-</div>
 
 ## Argument Reference
 

--- a/src/terraform/docs/r/archive.md
+++ b/src/terraform/docs/r/archive.md
@@ -34,13 +34,6 @@ resource "sakuracloud_archive" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#resource/archive" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#resource/archive"></iframe>
-
-</div>
 
 ## Argument Reference
 

--- a/src/terraform/docs/r/archive_share.md
+++ b/src/terraform/docs/r/archive_share.md
@@ -14,13 +14,6 @@ resource "sakuracloud_archive_share" "share_info" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#resource/archive_share" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#resource/archive_share"></iframe>
-
-</div>
 
 ## Argument Reference
 

--- a/src/terraform/docs/r/auto_backup.md
+++ b/src/terraform/docs/r/auto_backup.md
@@ -16,13 +16,6 @@ resource "sakuracloud_auto_backup" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#resource/auto_backup" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#resource/auto_backup"></iframe>
-
-</div>
 
 
 ## Argument Reference

--- a/src/terraform/docs/r/auto_scale.md
+++ b/src/terraform/docs/r/auto_scale.md
@@ -39,13 +39,6 @@ resource "sakuracloud_server" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#resource/auto_scale" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#resource/auto_scale"></iframe>
-
-</div>
 
 
 ## Argument Reference

--- a/src/terraform/docs/r/bridge.md
+++ b/src/terraform/docs/r/bridge.md
@@ -23,13 +23,6 @@ resource "sakuracloud_bridge" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#resource/bridge" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#resource/bridge"></iframe>
-
-</div>
 
 
 ## Argument Reference

--- a/src/terraform/docs/r/cdrom.md
+++ b/src/terraform/docs/r/cdrom.md
@@ -12,13 +12,6 @@ resource "sakuracloud_cdrom" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#resource/cdrom" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#resource/cdrom"></iframe>
-
-</div>
 
 
 ## Argument Reference

--- a/src/terraform/docs/r/certificate_authority.md
+++ b/src/terraform/docs/r/certificate_authority.md
@@ -139,13 +139,6 @@ resource "sakuracloud_certificate_authority" "foobar" {
 
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#resource/certificate_authority" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#resource/certificate_authority"></iframe>
-
-</div>
 
 
 ## Argument Reference

--- a/src/terraform/docs/r/container_registry.md
+++ b/src/terraform/docs/r/container_registry.md
@@ -43,13 +43,6 @@ resource "sakuracloud_container_registry" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#resource/container_registry" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#resource/container_registry"></iframe>
-
-</div>
 
 
 ## Argument Reference

--- a/src/terraform/docs/r/database.md
+++ b/src/terraform/docs/r/database.md
@@ -46,13 +46,6 @@ resource "sakuracloud_switch" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#resource/database" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#resource/database"></iframe>
-
-</div>
 
 ## Argument Reference
 

--- a/src/terraform/docs/r/database_read_replica.md
+++ b/src/terraform/docs/r/database_read_replica.md
@@ -20,13 +20,6 @@ data sakuracloud_database "master" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#resource/database_read_replica" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#resource/database_read_replica"></iframe>
-
-</div>
 
 
 ## Argument Reference

--- a/src/terraform/docs/r/disk.md
+++ b/src/terraform/docs/r/disk.md
@@ -21,13 +21,6 @@ resource "sakuracloud_disk" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#resource/disk" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#resource/disk"></iframe>
-
-</div>
 
 
 ## Argument Reference

--- a/src/terraform/docs/r/dns.md
+++ b/src/terraform/docs/r/dns.md
@@ -20,13 +20,6 @@ resource "sakuracloud_dns" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#resource/dns" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#resource/dns"></iframe>
-
-</div>
 
 
 ## Argument Reference

--- a/src/terraform/docs/r/dns_record.md
+++ b/src/terraform/docs/r/dns_record.md
@@ -22,13 +22,6 @@ resource "sakuracloud_dns_record" "record2" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#resource/dns_record" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#resource/dns_record"></iframe>
-
-</div>
 
 
 ## Argument Reference

--- a/src/terraform/docs/r/enhanced_db.md
+++ b/src/terraform/docs/r/enhanced_db.md
@@ -18,13 +18,6 @@ resource "sakuracloud_enhanced_db" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#resource/enhanced_db" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#resource/enhanced_db"></iframe>
-
-</div>
 
 ## Argument Reference
 

--- a/src/terraform/docs/r/esme.md
+++ b/src/terraform/docs/r/esme.md
@@ -10,13 +10,6 @@ resource "sakuracloud_esme" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#resource/esme" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#resource/esme"></iframe>
-
-</div>
 
 
 ## Argument Reference

--- a/src/terraform/docs/r/gslb.md
+++ b/src/terraform/docs/r/gslb.md
@@ -32,13 +32,6 @@ resource "sakuracloud_gslb" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#resource/gslb" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#resource/gslb"></iframe>
-
-</div>
 
 
 ## Argument Reference

--- a/src/terraform/docs/r/icon.md
+++ b/src/terraform/docs/r/icon.md
@@ -11,13 +11,6 @@ resource "sakuracloud_icon" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#resource/icon" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#resource/icon"></iframe>
-
-</div>
 
 
 ## Argument Reference

--- a/src/terraform/docs/r/internet.md
+++ b/src/terraform/docs/r/internet.md
@@ -15,13 +15,6 @@ resource "sakuracloud_internet" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#resource/internet" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#resource/internet"></iframe>
-
-</div>
 
 
 ## Argument Reference

--- a/src/terraform/docs/r/load_balancer.md
+++ b/src/terraform/docs/r/load_balancer.md
@@ -45,13 +45,6 @@ resource "sakuracloud_switch" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#resource/load_balancer" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#resource/load_balancer"></iframe>
-
-</div>
 
 
 ## Argument Reference

--- a/src/terraform/docs/r/local_router.md
+++ b/src/terraform/docs/r/local_router.md
@@ -49,13 +49,6 @@ data "sakuracloud_local_router" "peer" {
 
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#resource/local_router" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#resource/local_router"></iframe>
-
-</div>
 
 ## Argument Reference
 

--- a/src/terraform/docs/r/mobile_gateway.md
+++ b/src/terraform/docs/r/mobile_gateway.md
@@ -47,13 +47,6 @@ resource "sakuracloud_switch" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#resource/mobile_gateway" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#resource/mobile_gateway"></iframe>
-
-</div>
 
 
 ## Argument Reference

--- a/src/terraform/docs/r/nfs.md
+++ b/src/terraform/docs/r/nfs.md
@@ -24,13 +24,6 @@ resource "sakuracloud_switch" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#resource/nfs" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#resource/nfs"></iframe>
-
-</div>
 
 ## Argument Reference
 

--- a/src/terraform/docs/r/note.md
+++ b/src/terraform/docs/r/note.md
@@ -9,13 +9,6 @@ resource "sakuracloud_note" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#resource/note" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#resource/note"></iframe>
-
-</div>
 
 
 ## Argument Reference

--- a/src/terraform/docs/r/packet_filter.md
+++ b/src/terraform/docs/r/packet_filter.md
@@ -58,13 +58,6 @@ resource "sakuracloud_packet_filter" "foobar" {
     その場合はパケットフィルタルールリソース(`sakuracloud_packet_filter_rules`)をご利用ください。
 
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#resource/packet_filter" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#resource/packet_filter"></iframe>
-
-</div>
 
 
 ## Argument Reference

--- a/src/terraform/docs/r/packet_filter_rules.md
+++ b/src/terraform/docs/r/packet_filter_rules.md
@@ -57,13 +57,6 @@ resource "sakuracloud_packet_filter_rules" "rules" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#resource/packet_filter_rules" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#resource/packet_filter_rules"></iframe>
-
-</div>
 
 ## Argument Reference
 

--- a/src/terraform/docs/r/private_host.md
+++ b/src/terraform/docs/r/private_host.md
@@ -10,13 +10,6 @@ resource "sakuracloud_private_host" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#resource/private_host" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#resource/private_host"></iframe>
-
-</div>
 
 
 ## Argument Reference

--- a/src/terraform/docs/r/proxylb.md
+++ b/src/terraform/docs/r/proxylb.md
@@ -62,13 +62,6 @@ resource sakuracloud_server "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#resource/proxylb" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#resource/proxylb"></iframe>
-
-</div>
 
 
 ## Argument Reference

--- a/src/terraform/docs/r/proxylb_acme.md
+++ b/src/terraform/docs/r/proxylb_acme.md
@@ -22,13 +22,6 @@ data "sakuracloud_proxylb" "foobar" {
     このリソースを利用する場合、エンハンスドロードバランサリソース(`sakuracloud_proxylb`)の`certificate`ブロックの値は上書きされます。  
     両者の同時指定はできません。
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#resource/proxylb_acme" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#resource/proxylb_acme"></iframe>
-
-</div>
 
 ## Argument Reference
 

--- a/src/terraform/docs/r/server.md
+++ b/src/terraform/docs/r/server.md
@@ -46,13 +46,6 @@ resource "sakuracloud_disk" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#resource/server" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#resource/server"></iframe>
-
-</div>
 
 
 ## Argument Reference

--- a/src/terraform/docs/r/sim.md
+++ b/src/terraform/docs/r/sim.md
@@ -17,13 +17,6 @@ resource "sakuracloud_sim" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#resource/sim" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#resource/sim"></iframe>
-
-</div>
 
 
 ## Argument Reference

--- a/src/terraform/docs/r/simple_monitor.md
+++ b/src/terraform/docs/r/simple_monitor.md
@@ -28,13 +28,6 @@ resource "sakuracloud_simple_monitor" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#resource/simple_monitor" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#resource/simple_monitor"></iframe>
-
-</div>
 
 
 ## Argument Reference

--- a/src/terraform/docs/r/ssh_key.md
+++ b/src/terraform/docs/r/ssh_key.md
@@ -9,13 +9,6 @@ resource "sakuracloud_ssh_key" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#resource/ssh_key" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#resource/ssh_key"></iframe>
-
-</div>
 
 
 ## Argument Reference

--- a/src/terraform/docs/r/switch.md
+++ b/src/terraform/docs/r/switch.md
@@ -10,13 +10,6 @@ resource "sakuracloud_switch" "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#resource/switch" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#resource/switch"></iframe>
-
-</div>
 
 ## Argument Reference
 

--- a/src/terraform/docs/r/vpc_router.md
+++ b/src/terraform/docs/r/vpc_router.md
@@ -161,13 +161,6 @@ resource sakuracloud_switch "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#resource/vpc_router" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#resource/vpc_router"></iframe>
-
-</div>
 
 
 ## Argument Reference

--- a/src/terraform/docs/r/webaccel_acl.md
+++ b/src/terraform/docs/r/webaccel_acl.md
@@ -18,13 +18,6 @@ data sakuracloud_webaccel "site" {
  }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#resource/webaccel_acl" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#resource/webaccel_acl"></iframe>
-
-</div>
 
 ## Argument Reference
 

--- a/src/terraform/docs/r/webaccel_certificate.md
+++ b/src/terraform/docs/r/webaccel_certificate.md
@@ -16,13 +16,6 @@ resource sakuracloud_webaccel_certificate "foobar" {
 }
 ```
 
-<div class="editor">
-
-<h2><a href="https://zouen-alpha.usacloud.jp/#resource/webaccel_certificate" target="_blank" rel="noopener noreferrer">Code Editor</a></h2>
-
-<iframe src="https://zouen-alpha.usacloud.jp/#resource/webaccel_certificate"></iframe>
-
-</div>
 
 ## Argument Reference
 


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

issueなし

### このPRはどういう変更を行いますか？

Terraform Provider ドキュメントに埋め込まれていた `zouen-alpha.usacloud.jp` への Code Editor リンク・iframe を68ファイルから削除した。

現在ではAIにコード生成する場面が増えたため不要と判断した。

### ドキュメントの変更は必要ですか？

不要