### PR TITLE
docs: deprecate container_registry access_level

### DIFF
--- a/src/terraform/docs/d/container_registry.md
+++ b/src/terraform/docs/d/container_registry.md
@@ -35,7 +35,7 @@ data "sakuracloud_container_registry" "foobar" {
 * `id` - ID
 * `access_level` - アクセスレベル。ユーザーがコンテナレジストリにアクセスできる操作のレベルを表す  
   次のいずれかの値となる。[`readonly`/`none`]  
-  注: コンテナレジストリの公開設定(Pullのみ)は廃止予定となり、今後は`none`固定での運用となります
+  **Deprecated**: コンテナレジストリの公開設定(Pullのみ)は廃止予定となり、今後は`none`固定での運用となります
 * `description` - 説明
 * `fqdn` - コンテナレジストリにアクセスするためのFQDN
 * `icon_id` - アイコンID

--- a/src/terraform/docs/d/container_registry.md
+++ b/src/terraform/docs/d/container_registry.md
@@ -35,7 +35,7 @@ data "sakuracloud_container_registry" "foobar" {
 * `id` - ID
 * `access_level` - アクセスレベル。ユーザーがコンテナレジストリにアクセスできる操作のレベルを表す  
   次のいずれかの値となる。[`readonly`/`none`]  
-  〜注: コンテナレジストリの公開設定(Pullのみ)は廃止予定となり、今後は`none`固定での運用となります。〜
+  注: コンテナレジストリの公開設定(Pullのみ)は廃止予定となり、今後は`none`固定での運用となります
 * `description` - 説明
 * `fqdn` - コンテナレジストリにアクセスするためのFQDN
 * `icon_id` - アイコンID

--- a/src/terraform/docs/d/container_registry.md
+++ b/src/terraform/docs/d/container_registry.md
@@ -34,7 +34,8 @@ data "sakuracloud_container_registry" "foobar" {
 
 * `id` - ID
 * `access_level` - アクセスレベル。ユーザーがコンテナレジストリにアクセスできる操作のレベルを表す  
-次のいずれかの値となる。[`readonly`/`none`]
+  次のいずれかの値となる。[`readonly`/`none`]  
+  〜注: コンテナレジストリの公開設定(Pullのみ)は廃止予定となり、今後は`none`固定での運用となります。〜
 * `description` - 説明
 * `fqdn` - コンテナレジストリにアクセスするためのFQDN
 * `icon_id` - アイコンID

--- a/src/terraform/docs/r/container_registry.md
+++ b/src/terraform/docs/r/container_registry.md
@@ -47,8 +47,8 @@ resource "sakuracloud_container_registry" "foobar" {
 ## Argument Reference
 
 * `name` - (Required) 名前 / `1`-`64`文字で指定
-* `access_level` - (Optional) アクセスレベル / この値は次のいずれかを指定［`readonly`/`none`]/ デフォルト: `none`
-  〜`Deprecated`: コンテナレジストリの公開設定(Pullのみ)は廃止予定となり、今後は`none`固定での運用となります。指定しない場合は`none`が適用されます。〜
+* `access_level` - (Optional) アクセスレベル / この値は次のいずれかを指定［`readonly`/`none`]/ デフォルト値は`none`  
+  **Deprecated**: コンテナレジストリの公開設定(Pullのみ)は廃止予定となり、今後は`none`固定での運用となります。指定しない場合は`none`が適用されます
 * `subdomain_label` - (Required) サブドメインラベル /  `1`-`64`文字で指定 / この値を変更するとリソースの再作成が行われる
 * `user` - (Optional) ユーザー設定のリスト。詳細は[userブロック](#user)を参照
 * `virtual_domain` - (Optional) 独自ドメイン(FQDN)

--- a/src/terraform/docs/r/container_registry.md
+++ b/src/terraform/docs/r/container_registry.md
@@ -27,7 +27,6 @@ resource "sakuracloud_container_registry" "foobar" {
   name            = "foobar"
   virtual_domain  = "your-domain.example.com"
   subdomain_label = "your-subdomain-label"
-  access_level    = "readonly" # this must be one of ["readonly"/"none"]
 
   description = "description"
   tags        = ["tag1", "tag2"]
@@ -48,7 +47,8 @@ resource "sakuracloud_container_registry" "foobar" {
 ## Argument Reference
 
 * `name` - (Required) 名前 / `1`-`64`文字で指定
-* `access_level` - (Required) アクセスレベル / この値は次のいずれかを指定［`readonly`/`none`]
+* `access_level` - (Optional) アクセスレベル / この値は次のいずれかを指定［`readonly`/`none`]/ デフォルト: `none`
+  〜`Deprecated`: コンテナレジストリの公開設定(Pullのみ)は廃止予定となり、今後は`none`固定での運用となります。指定しない場合は`none`が適用されます。〜
 * `subdomain_label` - (Required) サブドメインラベル /  `1`-`64`文字で指定 / この値を変更するとリソースの再作成が行われる
 * `user` - (Optional) ユーザー設定のリスト。詳細は[userブロック](#user)を参照
 * `virtual_domain` - (Optional) 独自ドメイン(FQDN)

--- a/src/terraform/docs/r/container_registry.md
+++ b/src/terraform/docs/r/container_registry.md
@@ -47,7 +47,7 @@ resource "sakuracloud_container_registry" "foobar" {
 ## Argument Reference
 
 * `name` - (Required) 名前 / `1`-`64`文字で指定
-* `access_level` - (Optional) アクセスレベル / この値は次のいずれかを指定［`readonly`/`none`]/ デフォルト値は`none`  
+* `access_level` - (Optional/Deprecated) アクセスレベル / この値は次のいずれかを指定［`readonly`/`none`］/ デフォルト値は`none`  
   **Deprecated**: コンテナレジストリの公開設定(Pullのみ)は廃止予定となり、今後は`none`固定での運用となります。指定しない場合は`none`が適用されます
 * `subdomain_label` - (Required) サブドメインラベル /  `1`-`64`文字で指定 / この値を変更するとリソースの再作成が行われる
 * `user` - (Optional) ユーザー設定のリスト。詳細は[userブロック](#user)を参照


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

issueなし

### このPRはどういう変更を行いますか？

`sakuracloud_container_registry` の `access_level` 属性を非推奨にし、ドキュメントを更新します。

- リソースドキュメント (`r/container_registry.md`) の Example Usage から `access_level` の記述を削除
- `access_level` を `(Required)` から `(Optional)` に変更し、デフォルト値 `none` を明記
- `Deprecated` 注釈を追加し、公開設定(Pullのみ)は廃止予定で今後は `none` 固定となる旨を記載
- データソースドキュメント (`d/container_registry.md`) の `access_level` 属性にも同様の注釈を追加

背景: コンテナレジストリの公開設定（Pullのみ）は廃止予定となり、今後は一律「非公開」での運用となります。
参考: sacloud/terraform-provider-sakuracloud/pull/1390

### ドキュメントの変更は必要ですか？

不要（このPRがドキュメントの変更です）